### PR TITLE
Load bold and italic fonts, use single request

### DIFF
--- a/templates/head.html
+++ b/templates/head.html
@@ -11,11 +11,7 @@
     {{end}}
     <meta name="author" content="Michael G Sloan">
     <meta name="viewport" content="width=device-width, initial-scale=1"> <!-- TODO: is this still required in 2015? -->
-    <link href="https://fonts.googleapis.com/css?family=Alegreya" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Alegreya+Sans" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Alegreya+Sans+SC" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Inconsolata" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css?family=Playfair+Display" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Alegreya:700|Alegreya+Sans:400,400i,700|Alegreya+Sans+SC|Inconsolata:400,700|Playfair+Display:400,700" rel="stylesheet">
     <style>
       {{include page.css}}
     </style>


### PR DESCRIPTION
I was just browsing Reddit, and then I stumbled upon a page that looked familiar. I like what you did to it :)

You missed one thing though; by default the Google Fonts API sends only a stylesheet that includes the regular weight and style. If you want bold and italic, you have to explicitly ask for them. Otherwise the browser will generate one, which doesn’t work very well for serif fonts.

Before:
![mgsloan1](https://user-images.githubusercontent.com/506953/43368819-5c0eaa64-9363-11e8-98e8-4276de430b3b.png)

After:
![mgsloan2](https://user-images.githubusercontent.com/506953/43368822-620a6f16-9363-11e8-8e66-50416f6c72d1.png)

Also, all of the requests can be collapsed into one to reduce the number of roundtrips (when not using http/2) and to reduce the page size.